### PR TITLE
Added a positions page with the words from the general ad but no images

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,6 +16,7 @@ This CPT is a large collaborative project funded by NOAA and NSF.
 
    goals
    people
+   positions
    code
    data
    publications

--- a/doc/positions.md
+++ b/doc/positions.md
@@ -1,0 +1,44 @@
+# Positions
+
+Multiple postdoctoral research positions are available as part of a
+multi-institution Climate Process Team (CPT) on Ocean Transport and Eddy
+Energy. The CPT aims to survey, improve, and unify new advances in energy-,
+flow-, and scale-aware parameterizations of mesoscale eddies, in process
+studies and global ocean models; constrain parameters and parameterized fluxes
+through a synthesis of up-to-date observations of ocean energetics and
+transport; and implement and assess schemes within IPCC-class climate models at
+NCAR, NOAA-GFDL, and DOE-LANL. The expectation is that modernized,
+energetically-consistent mesoscale eddy parameterizations will significantly
+reduce climate model biases in ocean currents, stratification, and transport.
+
+- New York University (Supervised by Laure Zanna): Diagnose energy budgets from
+  high-resolution simulations; unify buoyancy and tracer closures; assessment
+  and parameterization of vertical energy structure; parameterization of the grey
+  zone.
+  More information will be available shortly.
+
+- University of Colorado, Boulder (Supervised by Ian Grooms): Assessment of 2D
+  eddy energy equation; parameterization of eddy energy transport;
+  parameterizing dissipation in the eddy energy equation.
+  More information wil be available shortly.
+
+- Woods Hole Oceanographic Institution (Supervised  by Sylvia Cole):
+  Characterizing scale-dependent EKE from observations; quasi-3D eddy buoyancy
+  and momentum statistics from observations; analysis of vertical eddy structure
+  in observations; synthesis of observations.
+  More information will be available shortly.
+
+- Princeton University (Supervised by Alistair Adcroft): Implementation and
+  assessment of extant parameterizations of mesoscale eddies in process,
+  idealized and global ocean models; consistent and optimized formulation of
+  closures; development and assessment of improved and unified closures;
+  evaluation of new closures in climate models.
+  More information will be available at <https://www.princeton.edu/acad-positions/position/>
+
+Applications must include a cover letter, a CV with a list of publications, a
+statement of research interests, and contact information of 3 references.
+Applicants wishing to be considered for positions in multiple institutions
+should indicate this in their cover letter, and submit a separate application
+to each position of interest. For more information email Laure Zanna
+(<mailto:laure.zanna@nyu.edu>), or any of the collaborating PIs listed above.
+


### PR DESCRIPTION
This adds a page "Positions" with the words from the general ad we drafted in google docs by the steering committee (https://docs.google.com/document/d/1bEmpcr-j3eUYhPrS_8cw9bjmqoN0xZjaxuJTE37wNsc/edit?usp=sharing).
- I have not included the images of institutional logos.
- I replaced the placeholder links to the specific ads with "will be available shortly".

Or we could forego this page and just upload a PDF?