### PR TITLE
Add link to proposal

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,6 +38,7 @@ We will implement and compare recently-developed energetically-consistent
 parametrizations in the NCAR, GFDL, and LANL climate
 models.
 
+The text of the proposal to NOAA and NSF can be found at https://doi.org/10.6084/m9.figshare.10105922.v1 .
 
 .. toctree::
    :maxdepth: 2

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -1,6 +1,11 @@
 Publications
 ============
 
+Proposal
+--------
+
+Zanna, Laure (2019): Proposal to CVP Climate Process Teams on "Ocean Transport and Eddy Energy". https://doi.org/10.6084/m9.figshare.10105922.v1
+
 Published
 ---------
 

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -1,11 +1,6 @@
 Publications
 ============
 
-Proposal
---------
-
-Zanna, Laure (2019): Proposal to CVP Climate Process Teams on "Ocean Transport and Eddy Energy". https://doi.org/10.6084/m9.figshare.10105922.v1
-
 Published
 ---------
 


### PR DESCRIPTION
I added a link to the proposal hosted on figshare but as explicit markdown rather than via the .bib file. Could do the latter except the citation is a little unusual and would need some fiddling to get the right info to appear.